### PR TITLE
Change keyword substitution from SVN to Git.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+app-common ident
+app.parameters ident
+clean-app-common ident
+deploy-common ident
+prep-common ident

--- a/app-common
+++ b/app-common
@@ -2,8 +2,7 @@
 # app - Run Tomcat servlet container.
 #     - 10/02/08, Russell Tokuyama (UH ITS)
 #
-# $Id: app-common 6096 2018-05-22 02:24:50Z cahana $
-# $URL: svn+ssh://svnd@repo.its.hawaii.edu/misint/appDaemon/branches/trunk/app-common $
+# $Id$
 #
 # Mod: 11/25/08, russ@hawaii.edu; Silenced error output of kill.
 #      12/10/08, jbeutel@hawaii.edu; added JMX and wait for stop before kill

--- a/app.parameters
+++ b/app.parameters
@@ -1,8 +1,7 @@
 # app.parameters - include from app, clean-app, prep, and deploy scripts.
 # Try to avoid modifying those scripts, to make them easier to maintain.
 #
-# $Id: app.parameters 5655 2016-05-06 02:01:07Z cahana $
-# $URL: svn+ssh://svnd@repo.its.hawaii.edu/misint/appDaemon/branches/trunk/app.parameters $
+# $Id$
 #
  
 # required, daemon's user name, e.g., APP_USER=casl2d

--- a/clean-app-common
+++ b/clean-app-common
@@ -2,8 +2,7 @@
 # clean-app - Clean up app's files.
 #           - 06/13/05, Russell Tokuyama (UH ITS)
 #
-# $Id: clean-app-common 4301 2010-08-05 21:23:59Z jbeutel $
-# $URL: svn+ssh://svnd@repo.its.hawaii.edu/misint/appDaemon/branches/trunk/clean-app-common $
+# $Id$
 #
 # Mod: 03/10/10, jbeutel@hawaii.edu; parameterize and allow for overrides
 #---------------------------------------------------------------------

--- a/deploy-common
+++ b/deploy-common
@@ -4,8 +4,7 @@
 #          See 0-README.txt.
 #        - 01/13/04, Russell Tokuyama
 #
-# $Id: deploy-common 4301 2010-08-05 21:23:59Z jbeutel $
-# $URL: svn+ssh://svnd@repo.its.hawaii.edu/misint/appDaemon/branches/trunk/deploy-common $
+# $Id$
 #
 # Mod: 04/18/06, russ@hawaii.edu; Added removal of old context config and work
 #                files.

--- a/prep-common
+++ b/prep-common
@@ -6,8 +6,7 @@
 #        See 0-README.txt.
 #      - 09/23/08, Russell Tokuyama
 #
-# $Id: prep-common 5461 2015-12-02 22:02:42Z cahana $
-# $URL: svn+ssh://svnd@repo.its.hawaii.edu/misint/appDaemon/branches/trunk/prep-common $
+# $Id$
 #
 # Mod: 
 #      03/10/10, jbeutel@hawaii.edu; parameterize and allow for overrides


### PR DESCRIPTION
Remove the $URL$ keyword, because it is N/A for Git.
Add .gitattributes with "ident" for files with $Id$,
to replace their SVN Id with the file's Git SHA.
This prevents those files from looking like they
came from SVN, and shows their version in Git,
when they are checked out from Git.