### PR TITLE
TAPS-959 enable deploy to prod ES RHEL7 hosts.

### DIFF
--- a/Jenkinsfile-prod
+++ b/Jenkinsfile-prod
@@ -1,3 +1,5 @@
+// This file configures the Jenkins job:
+// https://docci.pvt.hawaii.edu/cis/job/shared-app-daemon-scripts/job/deploy-shared-app-script-PROD/
 pipeline {
   agent any
   options {
@@ -6,11 +8,11 @@ pipeline {
   stages {
       stage('SCP *-common') {
           steps {
-//              sh 'scp *-common cisd@its30.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
-//              sh 'scp *-common cisd@its31.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
-//              sh 'scp *-common cisd@its32.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
-//              sh 'scp *-common cisd@its33.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
-//              sh 'scp *-common cisd@sec10.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
+              sh 'scp *-common cisd@its30.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
+              sh 'scp *-common cisd@its31.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
+              sh 'scp *-common cisd@its32.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
+              sh 'scp *-common cisd@its33.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
+              sh 'scp *-common cisd@sec10.pvt.hawaii.edu:/usr/local/bin/appDaemon/'
 //              sh 'scp *-common myiamd@iws03.its.hawaii.edu:/usr/local/bin/appDaemon/'
 //              sh 'scp *-common myiamd@iwa03.its.hawaii.edu:/usr/local/bin/appDaemon/'
 //              sh 'scp *-common myiamd@iwa01.its.hawaii.edu:/usr/local/bin/appDaemon/'


### PR DESCRIPTION
Leaving the old scripts on the RHEL6 hosts.  Not deploying to IAM’s RHEL7 hosts yet, because Michael wrote that his group is not working on that right now, although they plan to eventually. (Not sure about the names of the IAM hosts and users, either.)